### PR TITLE
feat: UI refresh + strong SEO for hydromark.in

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1346,3 +1346,192 @@ section {
 
 
 
+
+/* ============================================================
+   Hydromark refresh overrides (appended 2026-04-18)
+   ============================================================ */
+:root {
+  --hm-primary: #0B3D91;
+  --hm-primary-dark: #082f73;
+  --hm-accent: #22D3EE;
+  --hm-accent-dark: #06b6d4;
+  --hm-ink: #0F172A;
+  --hm-muted: #475569;
+  --hm-surface: #F8FAFC;
+}
+
+/* Top bar */
+#topbar { background: var(--hm-primary); color: #fff; }
+#topbar a, #topbar i { color: #fff !important; }
+#topbar a:hover { color: var(--hm-accent) !important; }
+
+/* Header + nav */
+#header { box-shadow: 0 2px 12px rgba(15,23,42,.06); }
+#logo img { max-height: 48px; width: auto; }
+#navbar a.nav-link { color: var(--hm-ink); font-weight: 600; }
+#navbar a.nav-link:hover,
+#navbar a.nav-link.active { color: var(--hm-primary); }
+
+/* Hero */
+#hero {
+  min-height: 80vh;
+  background: linear-gradient(135deg, rgba(11,61,145,.92), rgba(11,61,145,.70)),
+              radial-gradient(circle at 80% 20%, rgba(34,211,238,.35), transparent 60%),
+              #0B3D91;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  padding: 80px 0;
+}
+#hero .hero-inner { max-width: 820px; }
+#hero h1 {
+  font-family: 'Montserrat', 'Raleway', sans-serif;
+  font-weight: 700;
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  line-height: 1.15;
+  margin-bottom: 16px;
+  color: #fff;
+}
+#hero .lead {
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  color: #e2e8f0;
+  margin-bottom: 28px;
+}
+#hero .hero-ctas { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 24px; }
+#hero .hero-chips {
+  list-style: none; padding: 0; margin: 0;
+  display: flex; flex-wrap: wrap; gap: 8px;
+}
+#hero .hero-chips li {
+  background: rgba(255,255,255,.12);
+  border: 1px solid rgba(255,255,255,.25);
+  color: #fff;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: .85rem;
+}
+
+/* Buttons */
+.btn-hm {
+  display: inline-block;
+  border-radius: 12px;
+  padding: 12px 22px;
+  font-weight: 600;
+  text-decoration: none !important;
+  border: none;
+  cursor: pointer;
+  transition: transform .15s ease, box-shadow .15s ease, background .2s;
+  line-height: 1.2;
+}
+.btn-hm-primary { background: var(--hm-accent); color: var(--hm-ink) !important; }
+.btn-hm-primary:hover { background: var(--hm-accent-dark); color: var(--hm-ink) !important; transform: translateY(-1px); box-shadow: 0 10px 22px rgba(6,182,212,.35); }
+.btn-hm-secondary { background: #fff; color: var(--hm-primary) !important; border: 1px solid rgba(255,255,255,.6); }
+.btn-hm-secondary:hover { background: #f1f5f9; color: var(--hm-primary-dark) !important; transform: translateY(-1px); }
+
+/* About */
+#about h2 { font-family: 'Montserrat', sans-serif; color: var(--hm-ink); }
+#about .about-img img { border-radius: 16px; box-shadow: 0 12px 28px rgba(15,23,42,.10); }
+
+/* Services */
+#services .box {
+  background: #fff;
+  border-radius: 16px;
+  padding: 28px;
+  box-shadow: 0 6px 18px rgba(15,23,42,.05);
+  transition: transform .2s, box-shadow .2s;
+  height: 100%;
+}
+#services .box:hover { transform: translateY(-4px); box-shadow: 0 14px 32px rgba(15,23,42,.10); }
+#services .box .icon {
+  width: 56px; height: 56px; border-radius: 14px;
+  background: rgba(11,61,145,.08); color: var(--hm-primary);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 24px; margin-bottom: 16px;
+}
+#services .box .title { font-weight: 700; color: var(--hm-ink); margin-bottom: 8px; }
+#services .box .description { color: var(--hm-muted); margin: 0; }
+
+/* Why strip */
+.why-strip {
+  margin-top: 40px; padding: 24px; background: var(--hm-surface); border-radius: 16px;
+  text-align: center;
+}
+.why-strip i { font-size: 28px; color: var(--hm-primary); display: block; margin-bottom: 8px; }
+.why-strip h5 { font-size: .95rem; color: var(--hm-ink); margin: 0; font-weight: 600; }
+
+/* FAQ */
+#faq { background: var(--hm-surface); padding: 60px 0; }
+#faq .faq-list { max-width: 820px; margin: 0 auto; }
+#faq details {
+  background: #fff; border-radius: 12px; padding: 16px 20px;
+  margin-bottom: 12px; box-shadow: 0 4px 12px rgba(15,23,42,.04);
+  border: 1px solid #e2e8f0;
+}
+#faq summary {
+  font-weight: 600; color: var(--hm-ink); cursor: pointer;
+  list-style: none; position: relative; padding-right: 28px;
+}
+#faq summary::-webkit-details-marker { display: none; }
+#faq summary::after {
+  content: '+'; position: absolute; right: 0; top: 0;
+  font-size: 22px; color: var(--hm-primary); transition: transform .2s;
+}
+#faq details[open] summary::after { content: '−'; }
+#faq details p { margin: 12px 0 0; color: var(--hm-muted); }
+
+/* Contact */
+#contact .contact-info h3 { color: var(--hm-ink); }
+#contact .enquiry-form {
+  background: #fff; padding: 28px; border-radius: 16px;
+  box-shadow: 0 6px 18px rgba(15,23,42,.05); margin-top: 24px;
+}
+#contact .enquiry-form .form-control {
+  border: 1px solid #cbd5e1; border-radius: 10px; padding: 10px 12px;
+}
+#contact .enquiry-form .form-control:focus {
+  border-color: var(--hm-primary); box-shadow: 0 0 0 3px rgba(11,61,145,.15);
+  outline: none;
+}
+#contact .form-note { color: var(--hm-muted); margin-left: 10px; font-size: .85rem; }
+#contact .quick-actions { margin-top: 24px; }
+#contact .quick-actions .btn-hm { text-align: center; }
+
+/* Footer */
+#footer {
+  background: var(--hm-ink); color: #cbd5e1; padding: 50px 0 24px;
+}
+#footer h5 { color: #fff; font-weight: 700; margin-bottom: 14px; }
+#footer a { color: #cbd5e1; text-decoration: none; }
+#footer a:hover { color: var(--hm-accent); }
+#footer .footer-links { list-style: none; padding: 0; margin: 0; }
+#footer .footer-links li { margin-bottom: 8px; }
+#footer .copyright { color: #94a3b8; font-size: .9rem; border-top: 1px solid #1e293b; padding-top: 16px; }
+#footer address { font-style: normal; color: #94a3b8; }
+
+/* Sticky mobile CTA */
+.sticky-cta {
+  position: fixed; left: 0; right: 0; bottom: 0; z-index: 999;
+  display: none;
+  box-shadow: 0 -6px 18px rgba(15,23,42,.15);
+}
+.sticky-cta a {
+  flex: 1; text-align: center; padding: 14px 4px;
+  color: #fff !important; text-decoration: none;
+  font-weight: 600; font-size: .95rem;
+}
+.sticky-cta a i { margin-right: 6px; }
+.sticky-cta .call { background: #16a34a; }
+.sticky-cta .wa   { background: #25D366; }
+.sticky-cta .en   { background: var(--hm-primary); }
+@media (max-width: 767px) {
+  .sticky-cta { display: flex; }
+  main, #footer { padding-bottom: 60px; }
+}
+
+/* Responsive images + perf */
+img { max-width: 100%; height: auto; }
+iframe { max-width: 100%; }
+
+/* Back-to-top accent */
+.back-to-top { background: var(--hm-primary) !important; }
+.back-to-top:hover { background: var(--hm-primary-dark) !important; }

--- a/index.html
+++ b/index.html
@@ -1,19 +1,45 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-IN">
 
 <head>
   <meta charset="utf-8">
-  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-  <title>Hydromark</title>
-  <meta name="google-site-verification" content="rTX3nZxjSWASbMeChKzkSe_iR7zcacDISAimaEHMjpM" />
+  <!-- Primary SEO -->
+  <title>Hydromark — Garden Hoses, PVC & Hydraulic Hose Pipes in Coimbatore</title>
+  <meta name="description" content="Hydromark supplies premium garden hoses, PVC suction, braided & hydraulic hose pipes, fittings and irrigation solutions in Coimbatore, Tamil Nadu. Wholesale & retail with same-day dispatch.">
+  <meta name="keywords" content="garden hose Coimbatore, PVC hose pipe, braided hose, hydraulic hose, irrigation hose Tamil Nadu, hose supplier Coimbatore, Hydromark">
+  <meta name="author" content="Hydromark">
+  <meta name="robots" content="index,follow,max-image-preview:large">
+  <link rel="canonical" href="https://hydromark.in/">
+  <meta name="theme-color" content="#0B3D91">
+  <meta name="google-site-verification" content="rTX3nZxjSWASbMeChKzkSe_iR7zcacDISAimaEHMjpM">
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="en_IN">
+  <meta property="og:site_name" content="Hydromark">
+  <meta property="og:url" content="https://hydromark.in/">
+  <meta property="og:title" content="Hydromark — Garden & Hydraulic Hoses in Coimbatore">
+  <meta property="og:description" content="Premium hoses, fittings and irrigation supplies. Wholesale & retail in Coimbatore, Tamil Nadu.">
+  <meta property="og:image" content="https://hydromark.in/assets/img/HYDROMARK.svg">
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Hydromark — Hoses in Coimbatore">
+  <meta name="twitter:description" content="Garden, PVC, hydraulic hoses & fittings. Same-day dispatch from Coimbatore.">
+  <meta name="twitter:image" content="https://hydromark.in/assets/img/HYDROMARK.svg">
 
   <!-- Favicons -->
-  <link href="./assets/img/HYDROMARK.svg" rel="icon">
-  <link href="assets/img/apple-touch-icon.png" rel="apple-touch-icon">
+  <link rel="icon" href="./assets/img/HYDROMARK.svg">
+  <link rel="apple-touch-icon" href="assets/img/apple-touch-icon.png">
+
+  <!-- Perf hints -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
   <!-- Google Fonts -->
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,700,700i|Raleway:300,400,500,700,800|Montserrat:300,400,700" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700|Raleway:400,700|Montserrat:400,700&display=swap" rel="stylesheet">
 
   <!-- Vendor CSS Files -->
   <link href="assets/vendor/aos/aos.css" rel="stylesheet">
@@ -25,6 +51,102 @@
 
   <!-- Template Main CSS File -->
   <link href="assets/css/style.css" rel="stylesheet">
+
+  <!-- JSON-LD: LocalBusiness / HardwareStore -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "HardwareStore",
+    "@id": "https://hydromark.in/#business",
+    "name": "Hydromark",
+    "image": "https://hydromark.in/assets/img/HYDROMARK.svg",
+    "url": "https://hydromark.in/",
+    "telephone": "+91-97904-58993",
+    "email": "hydromark.india@gmail.com",
+    "priceRange": "₹₹",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "S.F 51, Thondamuthur Rd, Chandrakala Nagar, Nagaraja Puram, Veerakeralam",
+      "addressLocality": "Coimbatore",
+      "addressRegion": "Tamil Nadu",
+      "postalCode": "641007",
+      "addressCountry": "IN"
+    },
+    "geo": { "@type": "GeoCoordinates", "latitude": 11.0035, "longitude": 76.9093 },
+    "openingHoursSpecification": [{
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": ["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],
+      "opens": "10:00",
+      "closes": "18:00"
+    }],
+    "areaServed": ["Coimbatore","Tiruppur","Pollachi","Tamil Nadu"],
+    "sameAs": []
+  }
+  </script>
+
+  <!-- JSON-LD: Organization -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "Hydromark",
+    "url": "https://hydromark.in/",
+    "logo": "https://hydromark.in/assets/img/HYDROMARK.svg",
+    "contactPoint": [{
+      "@type": "ContactPoint",
+      "telephone": "+91-97904-58993",
+      "contactType": "sales",
+      "availableLanguage": ["en","ta"],
+      "areaServed": "IN"
+    }]
+  }
+  </script>
+
+  <!-- JSON-LD: WebSite -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "url": "https://hydromark.in/",
+    "name": "Hydromark",
+    "inLanguage": "en-IN"
+  }
+  </script>
+
+  <!-- JSON-LD: FAQPage -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What types of hoses does Hydromark supply?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Hydromark supplies garden hoses, PVC suction hoses, braided hoses, hydraulic hoses, irrigation lines, hose reels and related fittings for home, farm and industrial use." }
+      },
+      {
+        "@type": "Question",
+        "name": "Do you deliver across Tamil Nadu?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Yes. We dispatch the same day for Coimbatore and surrounding areas, and ship across Tamil Nadu on request." }
+      },
+      {
+        "@type": "Question",
+        "name": "Do you offer wholesale pricing?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Yes. We offer wholesale pricing for dealers, farms and industrial buyers. Share your requirement on WhatsApp for a quote." }
+      },
+      {
+        "@type": "Question",
+        "name": "What are your business hours?",
+        "acceptedAnswer": { "@type": "Answer", "text": "We are open Monday to Saturday, 10:00 AM to 6:00 PM." }
+      },
+      {
+        "@type": "Question",
+        "name": "How can I place an order?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Call or WhatsApp us at +91 97904 58993, or send an enquiry from the contact form on this page." }
+      }
+    ]
+  }
+  </script>
 </head>
 
 <body>
@@ -32,7 +154,8 @@
 
   <script>
     document.querySelector('body').addEventListener('click',function() {
-      document.querySelector('.popup-container').style.display = 'none';
+      var popup = document.querySelector('.popup-container');
+      if (popup) popup.style.display = 'none';
     });
   </script>
 
@@ -41,14 +164,8 @@
     <div class="container d-flex justify-content-center justify-content-md-between">
       <div class="contact-info d-flex align-items-center">
         <i class="bi bi-envelope d-flex align-items-center"><a href="mailto:hydromark.india@gmail.com">hydromark.india@gmail.com</a></i>
-        <i class="bi bi-phone d-flex align-items-center ms-4"><a href="tel:09790458993">9790458993</a></i>
+        <i class="bi bi-phone d-flex align-items-center ms-4"><a href="tel:+919790458993">+91 97904 58993</a></i>
       </div>
-      <!-- <div class="social-links d-none d-md-flex align-items-center">
-        <a href="#" class="twitter"><i class="bi bi-twitter"></i></a>
-        <a href="#" class="facebook"><i class="bi bi-facebook"></i></a>
-        <a href="#" class="instagram"><i class="bi bi-instagram"></i></a>
-        <a href="#" class="linkedin"><i class="bi bi-linkedin"></i></i></a>
-      </div> -->
     </div>
   </section><!-- End Top Bar-->
 
@@ -57,9 +174,7 @@
     <div class="container d-flex justify-content-between">
 
       <div id="logo">
-        <h1><a href="index.html"><img src="./assets/img/HYDROMARK.svg" ></span></a></h1>
-        <!-- Uncomment below if you prefer to use an image logo -->
-        <!-- <a href="index.html"><img src="assets/img/logo.png" alt=""></a>-->
+        <a href="index.html" aria-label="Hydromark home"><img src="./assets/img/HYDROMARK.svg" alt="Hydromark — hoses & pipes, Coimbatore"></a>
       </div>
 
       <nav id="navbar" class="navbar">
@@ -67,9 +182,8 @@
           <li><a class="nav-link scrollto active" href="#hero">Home</a></li>
           <li><a class="nav-link scrollto" href="#about">About</a></li>
           <li><a class="nav-link scrollto" href="#services">Services</a></li>
-          <!-- <li><a class="nav-link scrollto" href="#portfolio">Products</a></li> -->
+          <li><a class="nav-link scrollto" href="#faq">FAQ</a></li>
           <li><a class="nav-link scrollto" href="#contact">Contact</a></li>
-          <li><a href="index.html"></a><div class="g-signin2" data-onsuccess="onSignIn"></div></li>
         </ul>
         <i class="bi bi-list mobile-nav-toggle"></i>
       </nav><!-- .navbar -->
@@ -79,25 +193,43 @@
 
   <main id="main">
 
+    <!-- ======= Hero Section ======= -->
+    <section id="hero">
+      <div class="container" data-aos="fade-up">
+        <div class="hero-inner">
+          <h1>Garden, PVC &amp; Hydraulic Hoses in Coimbatore</h1>
+          <p class="lead">Premium hoses, fittings and irrigation supplies — wholesale &amp; retail, with same-day dispatch across Tamil Nadu.</p>
+          <div class="hero-ctas">
+            <a class="btn-hm btn-hm-primary" href="https://wa.me/919790458993?text=Hi%20Hydromark%2C%20I%20need%20a%20quote." rel="noopener" target="_blank">Get a Quote on WhatsApp</a>
+            <a class="btn-hm btn-hm-secondary" href="tel:+919790458993">Call +91 97904 58993</a>
+          </div>
+          <ul class="hero-chips">
+            <li>Coimbatore local</li>
+            <li>Wholesale &amp; Retail</li>
+            <li>Same-day dispatch</li>
+            <li>Quality-tested</li>
+          </ul>
+        </div>
+      </div>
+    </section><!-- End Hero Section -->
+
     <!-- ======= About Section ======= -->
     <section id="about">
       <div class="container" data-aos="fade-up">
         <div class="row">
           <div class="col-lg-6 about-img">
-            <img src="assets/img/img2.jpg" alt="">
+            <img src="assets/img/img2.jpg" alt="Hydromark hose collection on display, Coimbatore" loading="lazy">
           </div>
 
           <div class="col-lg-6 content">
             <h2>Your Trusted Partner for Expert Gardening and Quality Hoses</h2>
             <ul>
-              <li><i class="bi bi-check-circle"></i><b>Premium Quality, Lasting Performance:</b> Discover a meticulously curated selection of high-standard garden hoses designed to withstand the test of time.  Crafted from top-tier materials, our hoses are built to resist kinks, twists, and weather extremes, ensuring they remain a reliable companion for all your gardening needs.</li>
-              <li><i class="bi bi-check-circle"></i><b>Innovative Features for Effortless Use:</b> Experience gardening convenience with our hoses equipped with innovative technologies. </li>
-              <li><i class="bi bi-check-circle"></i><b>Expert Guidance and Unparalleled Customer Care:</b> Beyond offering exceptional garden hoses, we are your gardening partners.</li>
+              <li><i class="bi bi-check-circle"></i><b>Premium Quality, Lasting Performance:</b> A meticulously curated selection of high-standard hoses built to resist kinks, twists and weather extremes — a reliable companion for home, farm and industrial use.</li>
+              <li><i class="bi bi-check-circle"></i><b>Innovative Features for Effortless Use:</b> Hoses and fittings engineered for convenience, with pressure ratings suited to Indian conditions.</li>
+              <li><i class="bi bi-check-circle"></i><b>Expert Guidance and Unparalleled Customer Care:</b> More than a supplier — we help you pick the right hose, size and fittings for the job.</li>
             </ul>
-
           </div>
         </div>
-
       </div>
     </section><!-- End About Section -->
 
@@ -113,7 +245,7 @@
           <div class="col-lg-6" data-aos="fade-up" data-aos-delay="100">
             <div class="box">
               <div class="icon"><i class="bi bi-truck"></i></div>
-              <h4 class="title"><a href="">Speedy Satisfaction</a></h4>
+              <h4 class="title">Speedy Satisfaction</h4>
               <p class="description">Our efficient logistics network ensures that your order is processed promptly, so you can start enjoying your purchases without delay.</p>
             </div>
           </div>
@@ -121,49 +253,78 @@
           <div class="col-lg-6" data-aos="fade-up" data-aos-delay="200">
             <div class="box">
               <div class="icon"><i class="bi bi-clock-fill"></i></div>
-              <h4 class="title"><a href="">Flexibility at Your Fingertips</a></h4>
-              <p class="description">Say goodbye to time constraints and shop when it suits you best.</p>
+              <h4 class="title">Flexibility at Your Fingertips</h4>
+              <p class="description">Say goodbye to time constraints — reach out on WhatsApp any time and we will respond during business hours.</p>
             </div>
           </div>
 
           <div class="col-lg-6" data-aos="fade-up" data-aos-delay="300">
             <div class="box">
               <div class="icon"><i class="bi bi-list-check"></i></div>
-              <h4 class="title"><a href="">Collections</a></h4>
-              <p class="description">Explore an extensive selection of garden hoses designed to cater to every need. </p>
+              <h4 class="title">Collections</h4>
+              <p class="description">Explore an extensive selection of garden, PVC, braided and hydraulic hoses designed to cater to every need.</p>
             </div>
           </div>
 
           <div class="col-lg-6" data-aos="fade-up" data-aos-delay="400">
             <div class="box">
               <div class="icon"><i class="bi bi-hourglass-split"></i></div>
-              <h4 class="title"><a href="">Instant Gratification</a></h4>
-              <p class="description"> Need to make a purchase at an odd hour? With our 24/7 service, you can satisfy your needs immediately.</p>
+              <h4 class="title">Instant Gratification</h4>
+              <p class="description">Need to place an urgent order? Call or WhatsApp us and we will arrange same-day dispatch across Coimbatore.</p>
             </div>
           </div>
 
         </div>
 
-      </div>
-    </section><!-- End Services Section -->
-
-    <!-- ======= Clients Section ======= -->
-    <section id="clients">
-      <div class="container" data-aos="fade-up">
-        <div class="section-header">
-          <h2>Clients</h2>
-          <p>From essential services to top-quality products, we've curated a selection that reflects the diverse needs of our community. Whether it's dependable home solutions, professional services, or products that enhance daily life, you can trust that we've got you covered.<br>Our commitment to the community goes beyond transactions. We actively engage in local initiatives, support causes that matter, and strive to make a positive impact where we live and work.</p>
+        <!-- Why Hydromark strip -->
+        <div class="row gy-3 why-strip" data-aos="fade-up">
+          <div class="col-6 col-md-3"><i class="bi bi-geo-alt-fill"></i><h5>Coimbatore local</h5></div>
+          <div class="col-6 col-md-3"><i class="bi bi-lightning-charge-fill"></i><h5>Same-day dispatch</h5></div>
+          <div class="col-6 col-md-3"><i class="bi bi-cash-coin"></i><h5>Wholesale &amp; retail</h5></div>
+          <div class="col-6 col-md-3"><i class="bi bi-patch-check-fill"></i><h5>Quality-tested</h5></div>
         </div>
 
       </div>
-    </section><!-- End Clients Section -->
+    </section><!-- End Services Section -->
+
+    <!-- ======= FAQ Section ======= -->
+    <section id="faq">
+      <div class="container" data-aos="fade-up">
+        <div class="section-header">
+          <h2>Frequently Asked Questions</h2>
+        </div>
+
+        <div class="faq-list">
+          <details>
+            <summary>What types of hoses does Hydromark supply?</summary>
+            <p>Garden hoses, PVC suction hoses, braided hoses, hydraulic hoses, irrigation lines, hose reels and related fittings for home, farm and industrial use.</p>
+          </details>
+          <details>
+            <summary>Do you deliver across Tamil Nadu?</summary>
+            <p>Yes. We dispatch the same day for Coimbatore and surrounding areas, and ship across Tamil Nadu on request.</p>
+          </details>
+          <details>
+            <summary>Do you offer wholesale pricing?</summary>
+            <p>Yes. We offer wholesale pricing for dealers, farms and industrial buyers. Share your requirement on WhatsApp for a quote.</p>
+          </details>
+          <details>
+            <summary>What are your business hours?</summary>
+            <p>Monday to Saturday, 10:00 AM to 6:00 PM.</p>
+          </details>
+          <details>
+            <summary>How can I place an order?</summary>
+            <p>Call or WhatsApp us at <a href="tel:+919790458993">+91 97904 58993</a>, or send an enquiry from the contact form below.</p>
+          </details>
+        </div>
+      </div>
+    </section><!-- End FAQ Section -->
 
     <!-- ======= Contact Section ======= -->
     <section id="contact">
       <div class="container" data-aos="fade-up">
         <div class="section-header">
           <h2>Contact Us</h2>
-          <p>No matter how you choose to get in touch, we're eager to hear from you. At Hydromark, communication is a two-way street, and we're dedicated to building a relationship based on transparency, respect, and exceptional service. Don't hesitate – contact us today and let's start a meaningful conversation.</p>
+          <p>No matter how you choose to get in touch, we are eager to hear from you. Call, WhatsApp, email — or send a quick enquiry below.</p>
         </div>
 
         <div class="row contact-info">
@@ -172,7 +333,7 @@
             <div class="contact-address">
               <i class="bi bi-geo-alt"></i>
               <h3>Address</h3>
-              <address>Chandrakala Nagar, S.F, 51, Thondamuthur Rd, Chandrakala Nagar, Nagaraja Puram, Veerakeralam, Tamil Nadu 641007</address>
+              <address>S.F 51, Thondamuthur Rd, Chandrakala Nagar, Nagaraja Puram, Veerakeralam, Coimbatore, Tamil Nadu 641007</address>
             </div>
           </div>
 
@@ -180,7 +341,8 @@
             <div class="contact-phone">
               <i class="bi bi-phone"></i>
               <h3>Phone Number</h3>
-              <p><a href="tel:09790458993">9790458993</a></p>
+              <p><a href="tel:+919790458993">+91 97904 58993</a></p>
+              <p><a href="https://wa.me/919790458993" rel="noopener" target="_blank">WhatsApp us</a></p>
             </div>
           </div>
 
@@ -188,37 +350,100 @@
             <div class="contact-email">
               <i class="bi bi-envelope"></i>
               <h3>Email</h3>
-              <p><a href="mailto: hydromark.india@gmail.com">hydromark.india@gmail.com</a></p>
+              <p><a href="mailto:hydromark.india@gmail.com">hydromark.india@gmail.com</a></p>
+              <p><small>Hours: Mon–Sat, 10:00–18:00</small></p>
             </div>
           </div>
 
         </div>
+
+        <!-- Enquiry form (mailto fallback, no backend) -->
+        <div class="row" data-aos="fade-up">
+          <div class="col-lg-7">
+            <form id="enquiryForm" class="enquiry-form" action="mailto:hydromark.india@gmail.com" method="post" enctype="text/plain">
+              <div class="row g-3">
+                <div class="col-md-6">
+                  <label for="ef-name" class="form-label">Your Name</label>
+                  <input type="text" class="form-control" id="ef-name" name="Name" required>
+                </div>
+                <div class="col-md-6">
+                  <label for="ef-phone" class="form-label">Phone</label>
+                  <input type="tel" class="form-control" id="ef-phone" name="Phone" required>
+                </div>
+                <div class="col-12">
+                  <label for="ef-product" class="form-label">Product / Requirement</label>
+                  <input type="text" class="form-control" id="ef-product" name="Product" placeholder="e.g. ½-inch garden hose, 20 m">
+                </div>
+                <div class="col-12">
+                  <label for="ef-message" class="form-label">Message</label>
+                  <textarea class="form-control" id="ef-message" name="Message" rows="4" required></textarea>
+                </div>
+                <div class="col-12">
+                  <button type="submit" class="btn-hm btn-hm-primary">Send Enquiry</button>
+                  <small class="form-note">Opens your email client to send the message.</small>
+                </div>
+              </div>
+            </form>
+          </div>
+          <div class="col-lg-5">
+            <div class="quick-actions">
+              <a class="btn-hm btn-hm-secondary w-100 mb-3" href="https://wa.me/919790458993?text=Hi%20Hydromark%2C%20I%20need%20a%20quote." rel="noopener" target="_blank"><i class="bi bi-whatsapp"></i> Chat on WhatsApp</a>
+              <a class="btn-hm btn-hm-primary w-100" href="tel:+919790458993"><i class="bi bi-telephone"></i> Call Now</a>
+            </div>
+          </div>
+        </div>
       </div>
 
       <div class="container mb-4">
-        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1164.3727846364377!2d76.90925739411149!3d11.003500430598315!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3ba85f899e9a0815%3A0xd174726e35f70aa6!2sDHANA%20PIPE%20CORPORATION!5e0!3m2!1sen!2sin!4v1692433523327!5m2!1sen!2sin" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+        <iframe title="Hydromark location on Google Maps" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1164.3727846364377!2d76.90925739411149!3d11.003500430598315!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3ba85f899e9a0815%3A0xd174726e35f70aa6!2sDHANA%20PIPE%20CORPORATION!5e0!3m2!1sen!2sin!4v1692433523327!5m2!1sen!2sin" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
       </div>
-      </section>
-
-    </section>
+    </section><!-- End Contact Section -->
 
   </main><!-- End #main -->
 
   <!-- ======= Footer ======= -->
   <footer id="footer">
     <div class="container">
-      <div class="copyright">
-        &copy; Copyright <strong>Hydromark</strong>. All Rights Reserved
+      <div class="row gy-3">
+        <div class="col-md-5">
+          <h5>Hydromark</h5>
+          <p>Garden, PVC &amp; hydraulic hose pipes, fittings and irrigation supplies. Wholesale &amp; retail in Coimbatore, Tamil Nadu.</p>
+          <address>S.F 51, Thondamuthur Rd, Veerakeralam, Coimbatore 641007</address>
+        </div>
+        <div class="col-6 col-md-3">
+          <h5>Quick Links</h5>
+          <ul class="footer-links">
+            <li><a href="#about">About</a></li>
+            <li><a href="#services">Services</a></li>
+            <li><a href="#faq">FAQ</a></li>
+            <li><a href="#contact">Contact</a></li>
+            <li><a href="termsncondition.html">Terms &amp; Conditions</a></li>
+          </ul>
+        </div>
+        <div class="col-6 col-md-4">
+          <h5>Reach Us</h5>
+          <ul class="footer-links">
+            <li><a href="tel:+919790458993">+91 97904 58993</a></li>
+            <li><a href="https://wa.me/919790458993" rel="noopener" target="_blank">WhatsApp</a></li>
+            <li><a href="mailto:hydromark.india@gmail.com">hydromark.india@gmail.com</a></li>
+            <li>Mon–Sat, 10:00–18:00</li>
+          </ul>
+        </div>
       </div>
-    </div>
-    <div class="container">
-      <div class="copyright">
-        <a href="termsncondition.html" id ="terms" style="color:#555;">Terms & Conditions</a>
+      <div class="copyright text-center mt-4">
+        &copy; <span id="yr"></span> <strong>Hydromark</strong>. All Rights Reserved.
       </div>
     </div>
   </footer><!-- End Footer -->
 
-  <a href="#" class="back-to-top d-flex align-items-center justify-content-center"><i class="bi bi-arrow-up-short"></i></a>
+  <!-- Sticky mobile CTA -->
+  <div class="sticky-cta" role="navigation" aria-label="Quick actions">
+    <a class="call" href="tel:+919790458993"><i class="bi bi-telephone"></i> Call</a>
+    <a class="wa" href="https://wa.me/919790458993" rel="noopener" target="_blank"><i class="bi bi-whatsapp"></i> WhatsApp</a>
+    <a class="en" href="#contact"><i class="bi bi-envelope"></i> Enquire</a>
+  </div>
+
+  <a href="#hero" class="back-to-top d-flex align-items-center justify-content-center" aria-label="Back to top"><i class="bi bi-arrow-up-short"></i></a>
 
   <!-- Vendor JS Files -->
   <script src="assets/vendor/aos/aos.js"></script>
@@ -226,15 +451,16 @@
   <script src="assets/vendor/glightbox/js/glightbox.min.js"></script>
   <script src="assets/vendor/isotope-layout/isotope.pkgd.min.js"></script>
   <script src="assets/vendor/swiper/swiper-bundle.min.js"></script>
-  <script src="assets/vendor/php-email-form/validate.js"></script>
 
   <!-- Template Main JS File -->
   <script src="assets/js/main.js"></script>
   <script>
     var loader = document.getElementById("preloader");
     window.addEventListener("load",function(){
-      loader.style.display='none'
+      if (loader) loader.style.display='none';
     });
+    var yr = document.getElementById("yr");
+    if (yr) yr.textContent = new Date().getFullYear();
   </script>
 
 </body>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+Disallow: /forms/
+
+Sitemap: https://hydromark.in/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,18 +1,15 @@
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-<!--  created with Free Online Sitemap Generator www.xml-sitemaps.com  -->
-<url>
-<loc>https://hydromark.in/</loc>
-<lastmod>2025-04-13T06:05:01+00:00</lastmod>
-<priority>1.00</priority>
-</url>
-<url>
-<loc>https://hydromark.in/index.html</loc>
-<lastmod>2025-04-13T06:05:01+00:00</lastmod>
-<priority>0.80</priority>
-</url>
-<url>
-<loc>https://hydromark.in/termsncondition.html</loc>
-<lastmod>2025-04-13T06:05:01+00:00</lastmod>
-<priority>0.80</priority>
-</url>
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://hydromark.in/</loc>
+    <lastmod>2026-04-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://hydromark.in/termsncondition.html</loc>
+    <lastmod>2026-04-18</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>

--- a/termsncondition.html
+++ b/termsncondition.html
@@ -1,12 +1,25 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-IN">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>HydroMark</title>
-  <title>Hydromark</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>Terms &amp; Conditions — Hydromark</title>
+  <meta name="description" content="Terms &amp; Conditions, returns, refunds and cancellation policy for Hydromark (Dhana Pipe Corporation), Coimbatore.">
+  <meta name="robots" content="index,follow">
+  <link rel="canonical" href="https://hydromark.in/termsncondition.html">
+  <meta name="theme-color" content="#0B3D91">
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Hydromark">
+  <meta property="og:title" content="Terms &amp; Conditions — Hydromark">
+  <meta property="og:description" content="Terms, returns and refunds policy for Hydromark, Coimbatore.">
+  <meta property="og:url" content="https://hydromark.in/termsncondition.html">
+  <meta property="og:image" content="https://hydromark.in/assets/img/HYDROMARK.svg">
+
   <!-- Favicons -->
-  <link href="./assets/img/HYDROMARK.svg" rel="icon">
+  <link rel="icon" href="./assets/img/HYDROMARK.svg">
+  <link rel="apple-touch-icon" href="assets/img/apple-touch-icon.png">
   <style>
     body {
       font-family: Arial, sans-serif;
@@ -25,6 +38,7 @@
   </style>
 </head>
 <body>
+  <p><a href="index.html">&larr; Back to Hydromark</a></p>
   <h1>Terms and Conditions</h1>
   <p>These Terms and Conditions (“Terms”) constitute a binding agreement between <strong>DHANA PIPE CORPORATION</strong> (“we,” “us,” or “our”) and you (“you” or “your”), governing your use of our website and/or purchase of goods/services from us (collectively, “Services”).</p>
   <p>By using our website and/or making a purchase from us, you expressly agree to the following Terms.</p>


### PR DESCRIPTION
- Add SEO head block: descriptive title, meta description, canonical, OG/Twitter cards, theme-color, preconnect hints
- Add JSON-LD: HardwareStore/LocalBusiness, Organization, WebSite, FAQPage
- Add real #hero section with H1, subhead and WhatsApp/Call CTAs
- Fix broken nav anchors (#hero was missing) and stray Google sign-in block
- Fix phone (+91 international format) and mailto (remove stray space)
- Replace empty service-card anchors; tighten copy
- Add Why Hydromark trust strip + FAQ section with native <details>
- Remove filler Clients section (no logos/testimonials)
- Add mailto-fallback enquiry form (no backend, works on GitHub Pages)
- Sticky mobile CTA bar (Call / WhatsApp / Enquire)
- Three-column branded footer with dynamic year, NAP, quick links
- Refresh sitemap.xml with current lastmod
- New robots.txt disallowing dead /forms/ dir
- Append Hydromark CSS overrides (palette, hero, cards, FAQ, form, footer)
- Terms page: SEO meta, duplicate title fix, back-to-home link